### PR TITLE
sweetalert導入

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,14 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  async redirects() {
+    return [
+      {
+        source: "/",
+        destination: "/search",
+        permanent: false,
+      },
+    ];
+  },
+};
 
 export default nextConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,10 +20,12 @@
         "next": "14.2.15",
         "react": "^18",
         "react-dom": "^18.3.1",
+        "react-loading": "^2.0.3",
         "reactstrap": "^9.2.3",
         "recharts": "^2.13.3",
         "sass": "^1.80.3",
-        "socket.io-client": "^4.8.0"
+        "socket.io-client": "^4.8.0",
+        "sweetalert2": "^11.4.8"
       },
       "devDependencies": {
         "@types/node": "^20",
@@ -7334,6 +7336,16 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
     },
+    "node_modules/react-loading": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/react-loading/-/react-loading-2.0.3.tgz",
+      "integrity": "sha512-Vdqy79zq+bpeWJqC+xjltUjuGApyoItPgL0vgVfcJHhqwU7bAMKzysfGW/ADu6i0z0JiOCRJjo+IkFNkRNbA3A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "prop-types": "^15.6.0",
+        "react": ">=0.14.0"
+      }
+    },
     "node_modules/react-popper": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-2.3.0.tgz",
@@ -8435,6 +8447,16 @@
       "resolved": "https://registry.npmjs.org/svg-tags/-/svg-tags-1.0.0.tgz",
       "integrity": "sha512-ovssysQTa+luh7A5Weu3Rta6FJlFBBbInjOh722LIt6klpU2/HtdUbszju/G4devcvk8PGt7FCLv5wftu3THUA==",
       "dev": true
+    },
+    "node_modules/sweetalert2": {
+      "version": "11.4.8",
+      "resolved": "https://registry.npmjs.org/sweetalert2/-/sweetalert2-11.4.8.tgz",
+      "integrity": "sha512-BDS/+E8RwaekGSxCPUbPnsRAyQ439gtXkTF/s98vY2l9DaVEOMjGj1FaQSorfGREKsbbxGSP7UXboibL5vgTMA==",
+      "license": "MIT",
+      "funding": {
+        "type": "individual",
+        "url": "https://sweetalert2.github.io/#donations"
+      }
     },
     "node_modules/synckit": {
       "version": "0.9.2",

--- a/package.json
+++ b/package.json
@@ -12,22 +12,24 @@
     "seed": "tsx ./prisma/seed.ts"
   },
   "dependencies": {
-    "@types/firebase": "^2.4.32",
-    "boostrap": "^2.0.0",
-    "firebase": "^11.0.2",
     "@emotion/react": "^11.13.5",
     "@emotion/styled": "^11.13.5",
     "@mui/material": "^6.1.8",
     "@prisma/client": "^6.0.0",
+    "@types/firebase": "^2.4.32",
     "@vercel/postgres": "^0.10.0",
+    "boostrap": "^2.0.0",
     "cuid": "^3.0.0",
+    "firebase": "^11.0.2",
     "next": "14.2.15",
     "react": "^18",
-    "recharts": "^2.13.3",
     "react-dom": "^18.3.1",
+    "react-loading": "^2.0.3",
     "reactstrap": "^9.2.3",
+    "recharts": "^2.13.3",
     "sass": "^1.80.3",
-    "socket.io-client": "^4.8.0"
+    "socket.io-client": "^4.8.0",
+    "sweetalert2": "^11.4.8"
   },
   "devDependencies": {
     "@types/node": "^20",

--- a/src/app/class-detail/[classNumber]/page.module.css
+++ b/src/app/class-detail/[classNumber]/page.module.css
@@ -28,3 +28,11 @@
 .post_button:hover {
   background-color: #1565c0;
 }
+
+.loadingContainer {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  height: 50vh;
+}

--- a/src/app/class-detail/[classNumber]/page.tsx
+++ b/src/app/class-detail/[classNumber]/page.tsx
@@ -7,6 +7,7 @@ import Rader from "../../../components/class-detail/Rader";
 import styles from "./page.module.css";
 import { Rating } from "@mui/material";
 import { CourseDetail } from "@/types/course";
+import ReactLoading from "react-loading";
 
 export default function ClassDetailPage() {
   const [classData, setClassData] = useState<CourseDetail | undefined>();
@@ -44,7 +45,11 @@ export default function ClassDetailPage() {
   };
 
   if (classData === undefined)
-    return <div className={styles.container}>Loading...</div>;
+    return (
+      <div className={styles.loadingContainer}>
+        <ReactLoading type="spokes" color="#444" height={130} width={130} />
+      </div>
+    );
 
   if (classData === null)
     return <div className={styles.container}>授業情報が見つかりません。</div>;

--- a/src/app/review/[classNumber]/page.tsx
+++ b/src/app/review/[classNumber]/page.tsx
@@ -7,12 +7,14 @@ import { TextInput } from "../../../components/Review/TextInput";
 import { useParams, useRouter } from "next/navigation";
 import styles from "./page.module.css";
 import { ReviewData } from "@/types/course";
+import Swal from "sweetalert2";
 
 export default function WebSocketPage() {
   const [clearityRating, setClarityRating] = useState<number | null>(null);
   const [testRating, setTestRating] = useState<number | null>(null);
   const [homeworkRating, setHomeworkRating] = useState<number | null>(null);
   const [comment, setComment] = useState<string>("");
+  const [isButtonDisabled, setIsButtonDisabled] = useState<boolean>(false);
   const { classNumber } = useParams();
   const router = useRouter();
 
@@ -23,7 +25,11 @@ export default function WebSocketPage() {
       testRating === null ||
       homeworkRating === null
     ) {
-      alert("全ての評価項目を入力してください。");
+      Swal.fire({
+        title: "入力エラー",
+        text: "全ての評価項目を入力してください",
+        icon: "warning",
+      });
       return;
     }
 
@@ -34,22 +40,27 @@ export default function WebSocketPage() {
       comment,
     };
 
+    setIsButtonDisabled(true);
     fetch(`/api/review/${classNumber}`, {
       method: "POST",
       body: JSON.stringify({ reviewData }),
     }).then((res) => {
-      if (res.status === 404) {
-        alert("授業情報が見つかりません");
-        return;
-      }
       if (res.status !== 200) {
-        alert("エラーが発生しました");
+        Swal.fire({
+          title: "エラーが発生しました",
+          text: "時間割番号が間違っている可能性があります",
+          icon: "error",
+        });
+        setIsButtonDisabled(false);
         return;
       }
-      alert("レビューを投稿しました");
+      Swal.fire({
+        title: "レビューを投稿しました",
+        icon: "success",
+      }).then(() => {
+        router.push("/search");
+      });
     });
-
-    router.push("/search");
   };
 
   return (
@@ -93,6 +104,7 @@ export default function WebSocketPage() {
         color="primary"
         onClick={funcSubmit}
         className={styles.submitButton}
+        disabled={isButtonDisabled}
       >
         投稿
       </Button>


### PR DESCRIPTION
closes https://github.com/Nitech-Board/nitech-board/issues/31
# What
### sweetalert導入
| エラー | 成功 |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/fb55f94c-161d-4559-ad29-6dbf48996942)|![image](https://github.com/user-attachments/assets/75cba530-5039-4748-a412-5f927fd5b6ab)| 

### ローディング導入
| ローディング画面|
|--------|
|![image](https://github.com/user-attachments/assets/fd32ee54-03cd-4b9f-a797-dc4834eb6df6)| 

### Topページから検索ページへリダイレクト
下のリンクを踏んでも`http://localhost:3000/search/`に飛ぶ
http://localhost:3000/