### PR TITLE
 firebase authenticationのメールリンクから、メール認証確認ページへ飛ぶように変更

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,7 @@
     "build": "npm run generate && next build",
     "start": "next start",
     "lint": "next lint",
-    "init": "prisma generate && prisma db push",
-    "generate": "prisma generate --sql && prisma db push",
+    "generate": "prisma generate --sql",
     "seed": "tsx ./prisma/seed.ts"
   },
   "dependencies": {

--- a/src/app/usermgmt/page.tsx
+++ b/src/app/usermgmt/page.tsx
@@ -1,0 +1,42 @@
+"use client";
+import handleResetPassword from "@/components/usemgmt/resetPasswordHandler";
+import { handleVerifyEmail } from "@/components/usemgmt/verifyEmailHandler";
+import { useSearchParams } from "next/navigation";
+import { Suspense, useEffect } from "react";
+
+// メールに届いたリンクをクリックしたときに呼ばれるページ
+// メールアドレスの確認、パスワードのリセットなどを行う
+// ex) https://nitech-board.vercel.app/auth?mode=verifyEmail&oobCode=xxxxxx
+function AuthPage() {
+  const searchParams = useSearchParams();
+  const mode = searchParams.get("mode"); // resetPassword, recoverEmail, verifyEmailのいずれか
+  const oobCode = searchParams.get("oobCode"); // firebaseが生成したコード
+
+  useEffect(() => {
+    if (!mode || !oobCode) return;
+    switch (mode) {
+      case "resetPassword":
+        handleResetPassword(oobCode);
+        break;
+      case "recoverEmail":
+        // TODO: 未実装
+        // Recover email
+        break;
+      case "verifyEmail":
+        handleVerifyEmail(oobCode);
+        break;
+    }
+  }, [mode, oobCode]);
+
+  return <div />;
+}
+
+// Suspenseを使ってページをラップする
+// searchParamsを使うために必要
+export default function SuspenseAuthPage() {
+  return (
+    <Suspense fallback={<div>Loading...</div>}>
+      <AuthPage />
+    </Suspense>
+  );
+}

--- a/src/components/usemgmt/resetPasswordHandler.ts
+++ b/src/components/usemgmt/resetPasswordHandler.ts
@@ -1,0 +1,51 @@
+import { auth } from "@/lib/FirebaseConfig";
+import { verifyPasswordResetCode, confirmPasswordReset } from "firebase/auth";
+import Swal from "sweetalert2";
+
+// パスワードのリセットを行う
+// メールに届いたパスワードリセットのリンクをクリックしたときに呼ばれる
+export default async function handleResetPassword(code: string) {
+  try {
+    // firebaseのAPIで、コードが有効か確認する
+    const accountEmail = await verifyPasswordResetCode(auth, code);
+
+    // パスワードの入力
+    const { value: newPassword } = await Swal.fire({
+      title: "Enter your password",
+      text: `Please enter a new password for ${accountEmail}`,
+      input: "password",
+      inputLabel: "Password",
+      inputPlaceholder: "Enter your password",
+      inputAttributes: {
+        maxlength: "20",
+        autocapitalize: "off",
+        autocorrect: "off",
+      },
+    });
+
+    try {
+      // 入力したパスワードを新しいパスワードとして設定する
+      const resp = await confirmPasswordReset(auth, code, newPassword);
+      console.log(resp);
+      Swal.fire({
+        icon: "success",
+        title: "成功",
+        text: "パスワードのリセットが完了しました。",
+      });
+    } catch (e: any) {
+      Swal.fire({
+        icon: "error",
+        title: "エラー",
+        text: `${e?.message ?? "パスワードのリセットに失敗しました。"}`,
+      });
+    }
+  } catch {
+    // Invalid or expired action code. Ask user to try to reset the password
+    // again.
+    Swal.fire({
+      icon: "error",
+      title: "エラー",
+      text: `パスワードのリセットに失敗しました。再度お試しください。`,
+    });
+  }
+}

--- a/src/components/usemgmt/verifyEmailHandler.ts
+++ b/src/components/usemgmt/verifyEmailHandler.ts
@@ -1,0 +1,31 @@
+import { auth } from "@/lib/FirebaseConfig";
+import { applyActionCode } from "firebase/auth";
+import Swal from "sweetalert2";
+
+// メールアドレスの認証を行う
+// メールに届いたメールアドレス確認のリンクをクリックしたときに呼ばれる
+export async function handleVerifyEmail(code: string) {
+  // メールアドレスの認証を行うかどうかの確認
+  const result = await Swal.fire({
+    title: "メールアドレスを認証",
+    text: "このメールアドレスを認証しますか？",
+    icon: "warning",
+    showCancelButton: true,
+  }).then((result) => {
+    return result.isConfirmed;
+  });
+
+  // メールアドレスの認証
+  if (result) {
+    try {
+      await applyActionCode(auth, code); // firebaseの機能でメールアドレスを認証
+      Swal.fire(
+        "メールアドレス認証完了",
+        "メールアドレスを認証しました",
+        "success"
+      );
+    } catch {
+      Swal.fire("エラー", "メールアドレスの認証に失敗しました。", "error");
+    }
+  }
+}


### PR DESCRIPTION
# Why
名工大のメールを用いた際、メールにリンクが含まれていると、（恐らくセキュリティシステムにより）勝手にリンクが踏まれてしまい、firebase authenticationのメール認証が自動で完了してしまう。

そのため、リンクを踏んだ瞬間にメール認証が完了するのではなく、リンクを踏んでからワンアクションを挟んでメールの認証をしたい。（リンクを踏む -> ボタンを押す -> メール認証完了！）

# What
確認ページを実装した。
メールに送られたリンクを踏んだときにこのページに飛ぶ。
| 確認ページ | 認証完了 |
|--------|--------|
|![image](https://github.com/user-attachments/assets/f9a2baf9-891f-4fe8-bf70-4e8c16eb5c8d)|![image](https://github.com/user-attachments/assets/dce28425-90fd-43cc-964c-bc27541fc480)|

# firebase側の変更点
メールで送信するリンクを`localhost:3000/usermgmt`に変更した。
これにより、上記で作成した確認ページに飛ぶようになる。
ただし、スマホから確認ページを見ることができないので注意。

※`npm run dev`している状態で、PCでoutlookからメールを確認し、リンクに飛ぶ
※開発時は迷惑メールフォルダに含まれている可能性が高いので注意
| firebase側の変更点 |
|--------|
| ![image](https://github.com/user-attachments/assets/2a0355b9-f1ca-4505-8a0d-90da800d81bd)| 

