### PR TITLE
auth provider作成

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from "next";
 import "../styles/global.css";
 import "@/lib/FirebaseConfig";
 import { APPLICATION_NAME } from "@/utils/const";
+import { AuthProvider } from "@/components/provider/AurhProvider";
 
 export const metadata: Metadata = {
   title: APPLICATION_NAME,
@@ -16,10 +17,12 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="ja">
-      <body>
-        <Header />
-        {children}
-      </body>
+      <AuthProvider>
+        <body>
+          <Header />
+          {children}
+        </body>
+      </AuthProvider>
     </html>
   );
 }

--- a/src/components/provider/AurhProvider.tsx
+++ b/src/components/provider/AurhProvider.tsx
@@ -1,0 +1,31 @@
+"use client";
+import { auth } from "@/lib/FirebaseConfig";
+import { onAuthStateChanged, User } from "firebase/auth";
+import React, { createContext, useEffect } from "react";
+import { useContext } from "react";
+
+// コンテキストを作成
+const AuthContext = createContext<User | null | undefined>(undefined);
+
+export function useAuth() {
+  // useContextで作成したコンテキストを呼び出す
+  return useContext(AuthContext);
+}
+
+interface AuthProviderProps {
+  children: React.ReactNode;
+}
+
+export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
+  const [user, setUser] = React.useState<User>(undefined);
+
+  useEffect(() => {
+    const unsubscribe = onAuthStateChanged(auth, (user) => {
+      setUser(user);
+    });
+
+    return unsubscribe;
+  }, []);
+
+  return <AuthContext.Provider value={user}>{children}</AuthContext.Provider>;
+};

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -1,0 +1,3 @@
+// export interface User {
+//   name: string;
+// }


### PR DESCRIPTION
This pull request introduces an authentication context using Firebase in the `src/app/layout.tsx` file. The most important changes include the addition of an `AuthProvider` component, the creation of an authentication context, and the integration of this context into the application's layout.

Authentication context integration:

* [`src/app/layout.tsx`](diffhunk://#diff-29d0a55f5ca1a9951042587f8b891bb4cd8b204f5bc855dc2468ed44cde2f5b3R6): Added `AuthProvider` to wrap the application layout, ensuring that authentication context is available throughout the app. [[1]](diffhunk://#diff-29d0a55f5ca1a9951042587f8b891bb4cd8b204f5bc855dc2468ed44cde2f5b3R6) [[2]](diffhunk://#diff-29d0a55f5ca1a9951042587f8b891bb4cd8b204f5bc855dc2468ed44cde2f5b3R20-R25)

Creation of `AuthProvider` component:

* [`src/components/provider/AurhProvider.tsx`](diffhunk://#diff-437e3251a58f93de4acb1bb8218b84f5b9d30f5ed13d3fc703c410a51b81a02fR1-R31): Created `AuthProvider` component to manage Firebase authentication state and provide it via context to the rest of the application.

Removal of unused code:

* [`src/types/user.ts`](diffhunk://#diff-08f03361c8ba099431787cddb0e1fece15ddf1939e33968cc455ede3d22fdf79R1-R3): Commented out the unused `User` interface.