### PR TITLE
授業詳細ページにレビューが乗るようにした。

### DIFF
--- a/src/app/class-detail/[classNumber]/page.tsx
+++ b/src/app/class-detail/[classNumber]/page.tsx
@@ -4,14 +4,15 @@ import { useState, useEffect } from "react";
 import { useParams, useRouter } from "next/navigation";
 import ClassData from "../../../components/class-detail/ClassData";
 import Rader from "../../../components/class-detail/Rader";
+import ReviewList from "../../../components/class-detail/ReviewList";
 import styles from "./page.module.css";
 import { Rating } from "@mui/material";
 import { CourseDetailWithReviews } from "@/types/course";
 
 export default function ClassDetailPage() {
   const [courseDataWithReviews, setCourseDataWithReviews] = useState<
-    CourseDetailWithReviews | undefined
-  >();
+    CourseDetailWithReviews | null | undefined
+  >(undefined);
   const [averageScore, setAverageScore] = useState<number | null>(null);
   const router = useRouter();
 
@@ -22,10 +23,7 @@ export default function ClassDetailPage() {
     fetch(`/api/course-detail/${classNumber}`)
       .then((res) => {
         if (res.status === 200) return res.json();
-        else {
-          setCourseDataWithReviews(null);
-          throw new Error("授業情報が見つかりません");
-        }
+        else throw new Error("授業情報が見つかりません");
       })
       .then((data) => {
         setCourseDataWithReviews(data);
@@ -66,7 +64,16 @@ export default function ClassDetailPage() {
         )}
       </h1>
       <ClassData details={courseDataWithReviews.course} />
-      <Rader onScoreCalculated={handleScoreCalculated} />
+      <Rader
+        reviews={courseDataWithReviews.reviews}
+        onScoreCalculated={handleScoreCalculated}
+      />
+      {courseDataWithReviews.reviews.length > 0 ? (
+        <ReviewList reviews={courseDataWithReviews.reviews} />
+      ) : (
+        <p className={styles.noReviews}>まだレビューがありません。</p>
+      )}
+
       <button onClick={handleAddReview} className={styles.post_button}>
         レビューを投稿
       </button>

--- a/src/components/class-detail/Rader.tsx
+++ b/src/components/class-detail/Rader.tsx
@@ -7,31 +7,47 @@ import {
   PolarRadiusAxis,
   ResponsiveContainer,
 } from "recharts";
+import { ReviewDataWithStudent } from "@/types/course";
 
 interface RaderProps {
+  reviews: ReviewDataWithStudent[];
   onScoreCalculated: (averageScore: number) => void;
 }
 
-function Rader({ onScoreCalculated }: RaderProps) {
+function Rader({ reviews, onScoreCalculated }: RaderProps) {
+  // レビューから各項目の平均を計算
+  const calculateAverage = (
+    key: keyof Pick<
+      ReviewDataWithStudent,
+      "clearityRating" | "testRating" | "homeworkRating"
+    >
+  ): number => {
+    if (reviews.length === 0) return 0; // レビューがない場合は0を返す
+
+    const total = reviews.reduce((sum, review) => sum + review[key], 0);
+    return total / reviews.length;
+  };
+
+  // レーダーチャート用データ
   const data = [
     {
       subject: "授業のわかりやすさ",
-      score: 3.75,
+      score: calculateAverage("clearityRating"),
       fullMark: 5,
     },
     {
       subject: "テストの簡単さ",
-      score: 4.2,
+      score: calculateAverage("testRating"),
       fullMark: 5,
     },
     {
       subject: "課題の楽さ",
-      score: 2.5,
+      score: calculateAverage("homeworkRating"),
       fullMark: 5,
     },
   ];
 
-  // 平均スコアを計算
+  // 全体の平均スコアを計算
   const averageScore =
     data.reduce((sum, item) => sum + item.score, 0) / data.length;
 

--- a/src/components/class-detail/ReviewList.module.css
+++ b/src/components/class-detail/ReviewList.module.css
@@ -1,0 +1,29 @@
+.reviewList {
+  margin-top: 20px;
+  width: 100%;
+}
+
+.reviewItem {
+  margin-bottom: 20px;
+  padding: 15px;
+  border: 1px solid #ddd;
+  border-radius: 8px;
+}
+
+.ratingSection {
+  margin-bottom: 10px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.commentSection {
+  margin-top: 10px;
+  gap: 10px;
+}
+
+.noReviews {
+  color: #666;
+  font-size: 16px;
+  text-align: center;
+}

--- a/src/components/class-detail/ReviewList.tsx
+++ b/src/components/class-detail/ReviewList.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+import styles from "./ReviewList.module.css";
+import { ReviewDataWithStudent } from "@/types/course";
+import { Rating } from "@mui/material";
+
+interface ReviewListProps {
+  reviews: ReviewDataWithStudent[];
+}
+
+const ReviewList: React.FC<ReviewListProps> = ({ reviews }) => {
+  return (
+    <div className={styles.reviewList}>
+      {reviews.map((review, index) => (
+        <div key={index} className={styles.reviewItem}>
+          <div className={styles.ratingSection}>
+            <strong>授業のわかりやすさ:</strong>
+            <Rating value={review.clearityRating} precision={0.1} readOnly />
+          </div>
+          <div className={styles.ratingSection}>
+            <strong>テストの簡単さ:</strong>
+            <Rating value={review.testRating} precision={0.1} readOnly />
+          </div>
+          <div className={styles.ratingSection}>
+            <strong>課題の楽さ:</strong>
+            <Rating value={review.homeworkRating} precision={0.1} readOnly />
+          </div>
+          {review.comment && (
+            <div className={styles.commentSection}>
+              <strong>コメント:</strong> {review.comment}
+            </div>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default ReviewList;


### PR DESCRIPTION
作成したこと
・レビューが下に乗るようにした。
・レーダーチャートとタイトル横の総合評価の値にレビューの結果が反映するようにした。

できていないこと
・レビュー欄の初めにユーザーネームと入学年度の表示
　→ユーザー名と入学年度の値の受け取り方がわかりませんでしたー。
・生成AIによるレビュー要約
　→いまいちどうゆう感じにすればいいのかわからなくて欄作成できてないっす。
